### PR TITLE
Add OPM file loading functionality and fix plugin name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,10 +82,10 @@ ctest --output-on-failure
 
 # Validate Audio Unit - minimal output
 auval -a
-auval -v aumu ChpS Hrki > /dev/null 2>&1 && echo "auval PASSED" || echo "auval FAILED"
+auval -v aumu YMul Hrki > /dev/null 2>&1 && echo "auval PASSED" || echo "auval FAILED"
 
 # Validate Audio Unit with full output (when debugging validation issues)
-auval -v aumu ChpS Hrki
+auval -v aumu YMul Hrki
 
 # Fix Audio Unit registration issues
 killall -9 AudioComponentRegistrar
@@ -365,7 +365,7 @@ uint8_t kc = (fnum >> YM2151Regs::SHIFT_KEY_CODE) & YM2151Regs::MASK_KEY_CODE;
 cmake --build . --parallel > /dev/null 2>&1 && echo "Build successful"
 
 # Audio Unit validation  
-auval -v aumu ChpS Hrki > /dev/null 2>&1 && echo "auval PASSED"
+auval -v aumu YMul Hrki > /dev/null 2>&1 && echo "auval PASSED"
 ```
 
 **🔒 These rules are derived from proven improvements that enhanced code quality, reduced bugs, and improved maintainability. Deviation requires explicit justification and documentation.**

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ cd build
 ctest --output-on-failure
 
 # Run Audio Unit validation (quiet)
-auval -v aumu ChpS Vend > /dev/null 2>&1 && echo "auval PASSED" || echo "auval FAILED"
+auval -v aumu YMul Hrki > /dev/null 2>&1 && echo "auval PASSED" || echo "auval FAILED"
 
 # Run Audio Unit validation (verbose for debugging)
-auval -v aumu ChpS Vend
+auval -v aumu YMul Hrki
 ```
 
 ## Current Development Status

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -161,10 +161,10 @@ gh auth login
 auval -a | grep -i ymulator
 
 # Validate specific component
-auval -v aumu ChpS Vend
+auval -v aumu YMul Hrki
 
 # Verbose validation output
-auval -v aumu ChpS Vend -w
+auval -v aumu YMul Hrki -w
 ```
 
 ### DAW Testing
@@ -193,13 +193,13 @@ ls -la ~/Library/Audio/Plug-Ins/Components/ | grep YMulator
 killall -9 AudioComponentRegistrar
 
 # Check AU registration
-auval -a | grep ChpS
+auval -a | grep YMul
 ```
 
 ### Validation Fails
 ```bash
 # Get detailed validation output
-auval -v aumu ChpS Vend -w
+auval -v aumu YMul Hrki -w
 
 # Check Info.plist
 plutil -p "~/Library/Audio/Plug-Ins/Components/YMulator Synth.component/Contents/Info.plist"

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -129,11 +129,11 @@ fi
 if [ "$VALIDATE" = true ]; then
     log_info "Running Audio Unit validation..."
     
-    if auval -v aumu ChpS Hrki > /dev/null 2>&1; then
+    if auval -v aumu YMul Hrki > /dev/null 2>&1; then
         log_success "Audio Unit validation passed"
     else
         log_warning "Audio Unit validation failed"
-        echo "Try running manually: auval -v aumu ChpS Hrki"
+        echo "Try running manually: auval -v aumu YMul Hrki"
     fi
 fi
 
@@ -148,6 +148,6 @@ echo "   Build & test:    ./scripts/build-dev.sh --validate"
 echo "   Release build:   ./scripts/build-release.sh"
 echo ""
 echo "🧪 Manual Testing:"
-echo "   auval -v aumu ChpS Hrki"
+echo "   auval -v aumu YMul Hrki"
 echo "   auval -a | grep -i ymulator"
 echo ""

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -125,7 +125,7 @@ if [ "$SKIP_VALIDATION" != "--skip-validation" ]; then
     
     # Run auval
     log_info "Running Audio Unit validation..."
-    if auval -v aumu ChpS Hrki > /dev/null 2>&1; then
+    if auval -v aumu YMul Hrki > /dev/null 2>&1; then
         log_success "Audio Unit validation passed"
     else
         log_warning "Audio Unit validation failed - continuing anyway"
@@ -274,7 +274,7 @@ A modern FM synthesis Audio Unit plugin bringing authentic YM2151 (OPM) sound to
 - Component Version: $BUNDLE_VERSION
 - Audio Unit Type: Music Device (aumu)
 - Manufacturer: Hrki
-- Subtype: ChpS
+- Subtype: YMul
 - Built with: JUCE + ymfm library
 - License: GPL v3
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ juce_add_plugin(YMulatorSynthAU
     # Basic information
     COMPANY_NAME "Hiroaki"
     PLUGIN_MANUFACTURER_CODE Hrki
-    PLUGIN_CODE ChpS
+    PLUGIN_CODE YMul
     PRODUCT_NAME "YMulator Synth"
     PLUGIN_DESCRIPTION "FM Synthesis Audio Unit"
     

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -647,6 +647,30 @@ void YMulatorSynthAudioProcessor::setCurrentPreset(int index)
     }
 }
 
+int YMulatorSynthAudioProcessor::loadOpmFile(const juce::File& file)
+{
+    CS_DBG("YMulatorSynthAudioProcessor::loadOpmFile - Loading file: " + file.getFullPathName());
+    
+    int numLoaded = presetManager.loadOPMFile(file);
+    
+    if (numLoaded > 0)
+    {
+        CS_DBG("Successfully loaded " + juce::String(numLoaded) + " presets from OPM file");
+        
+        // Notify ValueTree listeners that preset list has been updated
+        parameters.state.setProperty("presetListUpdated", juce::Random::getSystemRandom().nextInt(), nullptr);
+        
+        // Update host display to refresh preset list in DAW
+        updateHostDisplay();
+    }
+    else
+    {
+        CS_DBG("Failed to load any presets from OPM file");
+    }
+    
+    return numLoaded;
+}
+
 void YMulatorSynthAudioProcessor::loadPreset(int index)
 {
     // Assert valid preset index range

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -97,6 +97,9 @@ public:
     bool isInCustomMode() const { return isCustomPreset; }
     juce::String getCustomPresetName() const { return customPresetName; }
     
+    // OPM file operations
+    int loadOpmFile(const juce::File& file);
+    
 private:
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(YMulatorSynthAudioProcessor)

--- a/src/ui/MainComponent.h
+++ b/src/ui/MainComponent.h
@@ -33,6 +33,7 @@ private:
     // Preset selector
     std::unique_ptr<juce::ComboBox> presetComboBox;
     std::unique_ptr<juce::Label> presetLabel;
+    std::unique_ptr<juce::TextButton> loadOpmButton;
     
     // LFO controls
     std::unique_ptr<RotaryKnob> lfoRateKnob;
@@ -58,6 +59,9 @@ private:
     // Display components
     std::unique_ptr<AlgorithmDisplay> algorithmDisplay;
     
+    // File chooser
+    std::unique_ptr<juce::FileChooser> fileChooser;
+    
     // Parameter attachments
     std::unique_ptr<juce::Slider> feedbackHiddenSlider;
     std::unique_ptr<juce::Slider> lfoRateHiddenSlider;
@@ -81,6 +85,7 @@ private:
     void setupDisplayComponents();
     void updatePresetComboBox();
     void updateAlgorithmDisplay();
+    void loadOpmFileDialog();
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainComponent)
 };


### PR DESCRIPTION
## Summary
- Added Load button to UI for loading external .opm preset files
- Fixed plugin name display in GarageBand by updating plugin code from ChpS to YMul
- Updated build scripts and documentation to reflect the plugin code change

## Changes
### UI Improvements
- Added Load button next to preset dropdown in MainComponent
- Implemented file chooser dialog filtered for .opm files
- Display success/error messages after loading files
- Automatically select first loaded preset

### Plugin Registration Fix
- Changed PLUGIN_CODE from `ChpS` to `YMul` in CMakeLists.txt
- Updated all auval commands in build scripts to use new plugin code
- Now correctly displays as "YMulator Synth" in GarageBand

## Test plan
- [x] Build and install the plugin
- [x] Verify plugin appears as "YMulator Synth" in GarageBand
- [x] Test Load button opens file chooser
- [x] Test loading valid .opm files updates preset list
- [x] Test loading invalid files shows error message
- [x] Test preset selection after loading new files

🤖 Generated with [Claude Code](https://claude.ai/code)