### PR TITLE
Fix Import OPM Files dialog not opening

### DIFF
--- a/src/ui/MainComponent.cpp
+++ b/src/ui/MainComponent.cpp
@@ -825,6 +825,7 @@ void MainComponent::onBankChanged()
     
     // Check if "Import OPM File..." was selected
     if (selectedId == 9999) {
+        CS_DBG("Import OPM File option selected, opening file dialog");
         
         // Reset to previous bank selection (Factory by default)
         bankComboBox->setSelectedId(1, juce::dontSendNotification);
@@ -929,8 +930,9 @@ void MainComponent::updateAlgorithmDisplay()
 
 void MainComponent::loadOpmFileDialog()
 {
+    CS_DBG("loadOpmFileDialog() called - opening file chooser");
     
-    auto fileChooser = std::make_unique<juce::FileChooser>(
+    auto fileChooser = std::make_shared<juce::FileChooser>(
         "Select a VOPM preset file",
         juce::File::getSpecialLocation(juce::File::userDocumentsDirectory),
         "*.opm"
@@ -938,7 +940,7 @@ void MainComponent::loadOpmFileDialog()
     
     auto chooserFlags = juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles;
     
-    fileChooser->launchAsync(chooserFlags, [this](const juce::FileChooser& fc)
+    fileChooser->launchAsync(chooserFlags, [this, fileChooser](const juce::FileChooser& fc)
     {
         auto file = fc.getResult();
         


### PR DESCRIPTION
## Summary
- Fix critical issue where Import OPM Files dialog would not open when selected
- Resolve FileChooser memory management problem causing dialog to not appear

## Root Cause
FileChooser was using `unique_ptr` which got destroyed immediately after `launchAsync()` call, preventing the dialog from appearing.

## Solution
- Changed from `std::make_unique<FileChooser>` to `std::make_shared<FileChooser>`
- Capture FileChooser in lambda to extend its lifetime until dialog completion
- Added debug output to track Import OPM File selection process

## Test Results
- ✅ Import OPM Files option now successfully opens file selection dialog
- ✅ OPM file loading functions correctly after dialog selection
- ✅ User can import .opm files and they appear as new banks

## Files Changed
- `src/ui/MainComponent.cpp`: Fixed FileChooser memory management in `loadOpmFileDialog()`

🤖 Generated with [Claude Code](https://claude.ai/code)