### PR TITLE
Add missing fontconfig dependency for Linux builds

### DIFF
--- a/.github/workflows/build-cross-platform.yml
+++ b/.github/workflows/build-cross-platform.yml
@@ -119,6 +119,7 @@ jobs:
           ladspa-sdk \
           libcurl4-openssl-dev \
           libfreetype6-dev \
+          libfontconfig1-dev \
           libx11-dev \
           libxcomposite-dev \
           libxcursor-dev \
@@ -127,7 +128,8 @@ jobs:
           libxrandr-dev \
           libxrender-dev \
           libglu1-mesa-dev \
-          mesa-common-dev
+          mesa-common-dev \
+          pkg-config
     
     - name: Configure CMake (Linux)
       run: |


### PR DESCRIPTION
## Summary
Fix Linux build failures by adding missing fontconfig dependency required by JUCE.

## Problem
The Linux build in GitHub Actions was failing with:
```
Package 'fontconfig', required by 'virtual:world', not found
fatal error: ft2build.h: No such file or directory
```

## Solution
- Add `libfontconfig1-dev` package to the dependency list
- Add `pkg-config` for proper library detection

## Root Cause
JUCE's graphics module requires fontconfig for font rendering on Linux. While `libfreetype6-dev` was already included, fontconfig was missing, causing the build to fail when compiling juceaide.

## Test Status
- ✅ Windows build: **Success**
- ✅ macOS build: **Success**  
- 🔧 Linux build: **Will be fixed by this PR**

After merging this PR, all three platforms should build successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)