### PR TITLE
Fix GitHub Actions release permissions

### DIFF
--- a/.github/workflows/build-cross-platform.yml
+++ b/.github/workflows/build-cross-platform.yml
@@ -159,6 +159,8 @@ jobs:
   create-release:
     needs: [build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for creating releases
     
     steps:
     - name: Checkout code
@@ -214,8 +216,8 @@ jobs:
           # Auto-generate release notes
           VERSION=${{ steps.get_version.outputs.VERSION }}
           echo "NOTES<<EOF" >> $GITHUB_OUTPUT
-          cat << 'RELEASE_NOTES' >> $GITHUB_OUTPUT
-        ## YMulator Synth $VERSION
+          cat << RELEASE_NOTES >> $GITHUB_OUTPUT
+        ## YMulator Synth ${VERSION}
         
         ### 🎵 Cross-Platform Release
         


### PR DESCRIPTION
## Summary
Fix the release creation step in GitHub Actions workflow by adding necessary permissions.

## Problem
The create-release job was failing with:
```
Error: Error 403: Resource not accessible by integration
```

## Solution
1. Add `permissions: contents: write` to the create-release job
2. Fix VERSION variable expansion in release notes by removing quotes from heredoc

## Technical Details
- GitHub Actions requires explicit write permissions to create releases
- The default token permissions don't include release creation
- The VERSION variable wasn't expanding due to quoted heredoc

## Test Results
After this fix:
- ✅ All platform builds complete successfully
- ✅ Release creation will have proper permissions
- ✅ Version number will appear correctly in release notes

🤖 Generated with [Claude Code](https://claude.ai/code)