### PR TITLE
Change binary names from spaces to hyphens

### DIFF
--- a/.github/workflows/build-cross-platform.yml
+++ b/.github/workflows/build-cross-platform.yml
@@ -159,6 +159,8 @@ jobs:
   create-release:
     needs: [build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for creating releases
     
     steps:
     - name: Checkout code
@@ -214,8 +216,8 @@ jobs:
           # Auto-generate release notes
           VERSION=${{ steps.get_version.outputs.VERSION }}
           echo "NOTES<<EOF" >> $GITHUB_OUTPUT
-          cat << 'RELEASE_NOTES' >> $GITHUB_OUTPUT
-        ## YMulator Synth $VERSION
+          cat << RELEASE_NOTES >> $GITHUB_OUTPUT
+        ## YMulator Synth ${VERSION}
         
         ### 🎵 Cross-Platform Release
         

--- a/.github/workflows/build-cross-platform.yml
+++ b/.github/workflows/build-cross-platform.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Package Windows VST3
       run: |
         cd build
-        7z a YMulator-Synth-Windows-VST3.zip "src/YMulatorSynthAU_artefacts/Release/VST3/YMulator Synth.vst3"
+        7z a YMulator-Synth-Windows-VST3.zip "src/YMulator-Synth_artefacts/Release/VST3/YMulator-Synth.vst3"
     
     - name: Upload Windows artifacts
       uses: actions/upload-artifact@v4
@@ -86,9 +86,9 @@ jobs:
     - name: Package macOS plugins
       run: |
         cd build
-        zip -r YMulator-Synth-macOS-AU.zip "src/YMulatorSynthAU_artefacts/Release/AU/YMulator Synth.component"
-        zip -r YMulator-Synth-macOS-VST3.zip "src/YMulatorSynthAU_artefacts/Release/VST3/YMulator Synth.vst3"
-        zip -r YMulator-Synth-macOS-Standalone.zip "src/YMulatorSynthAU_artefacts/Release/Standalone/YMulator Synth.app"
+        zip -r YMulator-Synth-macOS-AU.zip "src/YMulator-Synth_artefacts/Release/AU/YMulator-Synth.component"
+        zip -r YMulator-Synth-macOS-VST3.zip "src/YMulator-Synth_artefacts/Release/VST3/YMulator-Synth.vst3"
+        zip -r YMulator-Synth-macOS-Standalone.zip "src/YMulator-Synth_artefacts/Release/Standalone/YMulator-Synth.app"
     
     - name: Upload macOS artifacts
       uses: actions/upload-artifact@v4
@@ -145,8 +145,8 @@ jobs:
     - name: Package Linux plugins
       run: |
         cd build
-        tar -czf YMulator-Synth-Linux-VST3.tar.gz "src/YMulatorSynthAU_artefacts/Release/VST3/YMulator Synth.vst3"
-        tar -czf YMulator-Synth-Linux-Standalone.tar.gz "src/YMulatorSynthAU_artefacts/Release/Standalone/YMulator Synth"
+        tar -czf YMulator-Synth-Linux-VST3.tar.gz "src/YMulator-Synth_artefacts/Release/VST3/YMulator-Synth.vst3"
+        tar -czf YMulator-Synth-Linux-Standalone.tar.gz "src/YMulator-Synth_artefacts/Release/Standalone/YMulator-Synth"
     
     - name: Upload Linux artifacts
       uses: actions/upload-artifact@v4

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Main plugin target
-juce_add_plugin(YMulatorSynthAU
+juce_add_plugin(YMulator-Synth
     # Basic information
     COMPANY_NAME "Hiroaki"
     PLUGIN_MANUFACTURER_CODE Hrki
     PLUGIN_CODE YMul
-    PRODUCT_NAME "YMulator Synth"
+    PRODUCT_NAME "YMulator-Synth"
     PLUGIN_DESCRIPTION "FM Synthesis Audio Unit"
     
     # Plugin formats
@@ -21,11 +21,11 @@ juce_add_plugin(YMulatorSynthAU
     AU_SANDBOX_SAFE TRUE
     
     # Categories and tags for GarageBand library
-    PLUGIN_AU_EXPORT_PREFIX YMulatorSynthAU
+    PLUGIN_AU_EXPORT_PREFIX YMulatorSynth
     
     # Other settings
     COPY_PLUGIN_AFTER_BUILD TRUE
-    PLUGIN_NAME "YMulator Synth"
+    PLUGIN_NAME "YMulator-Synth"
     
     # Install only AU to user directory
     AU_COPY_PLUGIN_AFTER_BUILD TRUE
@@ -35,7 +35,7 @@ juce_add_plugin(YMulatorSynthAU
 )
 
 # Source files
-target_sources(YMulatorSynthAU
+target_sources(YMulator-Synth
     PRIVATE
         PluginProcessor.cpp
         PluginEditor.cpp
@@ -58,7 +58,7 @@ target_sources(YMulatorSynthAU
 )
 
 # Include directories
-target_include_directories(YMulatorSynthAU
+target_include_directories(YMulator-Synth
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/include
@@ -66,7 +66,7 @@ target_include_directories(YMulatorSynthAU
 )
 
 # Link libraries
-target_link_libraries(YMulatorSynthAU
+target_link_libraries(YMulator-Synth
     PRIVATE
         juce::juce_audio_utils
         juce::juce_audio_processors
@@ -79,7 +79,7 @@ target_link_libraries(YMulatorSynthAU
 )
 
 # Compile definitions
-target_compile_definitions(YMulatorSynthAU
+target_compile_definitions(YMulator-Synth
     PUBLIC
         JUCE_DISPLAY_SPLASH_SCREEN=0
         JUCE_REPORT_APP_USAGE=0
@@ -89,20 +89,20 @@ target_compile_definitions(YMulatorSynthAU
 )
 
 # Add resources
-juce_add_binary_data(YMulatorSynthAU_Resources
+juce_add_binary_data(YMulator-Synth_Resources
     SOURCES
         ${CMAKE_SOURCE_DIR}/resources/presets/ymulator-synth-preset-collection.opm
 )
 
 # Link resources to the plugin
-target_link_libraries(YMulatorSynthAU
+target_link_libraries(YMulator-Synth
     PRIVATE
-        YMulatorSynthAU_Resources
+        YMulator-Synth_Resources
 )
 
 # Configure JUCE plugin
-configure_juce_target(YMulatorSynthAU)
+configure_juce_target(YMulator-Synth)
 
 # Set compiler warnings
-set_project_warnings(YMulatorSynthAU)
+set_project_warnings(YMulator-Synth)
 


### PR DESCRIPTION
## Summary
Update plugin binary names to use hyphens instead of spaces for better cross-platform file handling.

## Changes

### Binary Names
- **Before**: `YMulator Synth.vst3`, `YMulator Synth.component`, `YMulator Synth.app`
- **After**: `YMulator-Synth.vst3`, `YMulator-Synth.component`, `YMulator-Synth.app`

### CMake Configuration
- Change project name from `YMulatorSynthAU` to `YMulator-Synth`
- Update `PRODUCT_NAME` and `PLUGIN_NAME` to `"YMulator-Synth"`
- Update all target references consistently

### GitHub Actions
- Update workflow artifact paths to match new directory structure
- Maintain cross-platform build compatibility

## Benefits
- **Better Scripting**: No need to quote file paths with spaces
- **Cross-Platform**: Avoids potential issues with space handling in different shells
- **Consistency**: Aligns with common plugin naming conventions
- **Automation Friendly**: Easier integration with build and deployment scripts

## Compatibility
- **DAW Display**: Plugin will show as "YMulator-Synth" in DAWs
- **Functionality**: All features remain identical
- **Settings**: User settings and presets remain compatible

## Test Results
- ✅ macOS build successful with new binary names
- ✅ All plugin formats generate correctly (AU, VST3, Standalone)
- ✅ GitHub Actions paths updated to match new structure

🤖 Generated with [Claude Code](https://claude.ai/code)