### PR TITLE
Fix release notes generation syntax error

### DIFF
--- a/.github/workflows/build-cross-platform.yml
+++ b/.github/workflows/build-cross-platform.yml
@@ -216,42 +216,39 @@ jobs:
           # Auto-generate release notes
           VERSION=${{ steps.get_version.outputs.VERSION }}
           echo "NOTES<<EOF" >> $GITHUB_OUTPUT
-          cat << RELEASE_NOTES >> $GITHUB_OUTPUT
-        ## YMulator Synth ${VERSION}
-        
-        ### 🎵 Cross-Platform Release
-        
-        This release includes binaries for all supported platforms:
-        
-        #### 🪟 Windows
-        - VST3 plugin
-        - Standalone application
-        
-        #### 🍎 macOS
-        - Audio Unit (AU)
-        - Audio Unit v3 (AUv3)
-        - VST3 plugin
-        - Standalone application
-        
-        #### 🐧 Linux
-        - VST3 plugin
-        - Standalone application
-        
-        ### 📦 Installation
-        
-        1. Download the appropriate package for your platform
-        2. Extract the archive
-        3. Copy plugins to your plugin directory:
-           - **Windows VST3**: `C:\Program Files\Common Files\VST3\`
-           - **macOS AU**: `/Library/Audio/Plug-Ins/Components/`
-           - **macOS VST3**: `/Library/Audio/Plug-Ins/VST3/`
-           - **Linux VST3**: `~/.vst3/`
-        
-        ### 🙏 Acknowledgments
-        
-        Built with JUCE framework and ymfm emulation library.
-        
-        RELEASE_NOTES
+          echo "## YMulator-Synth ${VERSION}" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "### 🎵 Cross-Platform Release" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "This release includes binaries for all supported platforms:" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "#### 🪟 Windows" >> $GITHUB_OUTPUT
+          echo "- VST3 plugin" >> $GITHUB_OUTPUT
+          echo "- Standalone application" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "#### 🍎 macOS" >> $GITHUB_OUTPUT
+          echo "- Audio Unit (AU)" >> $GITHUB_OUTPUT
+          echo "- Audio Unit v3 (AUv3)" >> $GITHUB_OUTPUT
+          echo "- VST3 plugin" >> $GITHUB_OUTPUT
+          echo "- Standalone application" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "#### 🐧 Linux" >> $GITHUB_OUTPUT
+          echo "- VST3 plugin" >> $GITHUB_OUTPUT
+          echo "- Standalone application" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "### 📦 Installation" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "1. Download the appropriate package for your platform" >> $GITHUB_OUTPUT
+          echo "2. Extract the archive" >> $GITHUB_OUTPUT
+          echo "3. Copy plugins to your plugin directory:" >> $GITHUB_OUTPUT
+          echo "   - **Windows VST3**: \`C:\\Program Files\\Common Files\\VST3\\\`" >> $GITHUB_OUTPUT
+          echo "   - **macOS AU**: \`/Library/Audio/Plug-Ins/Components/\`" >> $GITHUB_OUTPUT
+          echo "   - **macOS VST3**: \`/Library/Audio/Plug-Ins/VST3/\`" >> $GITHUB_OUTPUT
+          echo "   - **Linux VST3**: \`~/.vst3/\`" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "### 🙏 Acknowledgments" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "Built with JUCE framework and ymfm emulation library." >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         fi
     


### PR DESCRIPTION
## Summary
Fix the bash syntax error in the release notes generation step that was causing workflow failures.

## Problem
The workflow was failing with:
```
unexpected EOF while looking for matching `'
bad substitution: no closing "`" in `
Invalid value. Matching delimiter not found 'EOF'
```

## Root Cause
The heredoc syntax `cat << RELEASE_NOTES` was causing issues in the GitHub Actions bash environment, particularly with:
- Command substitution conflicts
- Delimiter matching problems
- Variable expansion within heredoc

## Solution
Replace the heredoc approach with individual `echo` statements:
- Each line of the release notes is now a separate `echo` command
- Proper escaping of special characters (backslashes in Windows paths)
- Cleaner and more predictable output generation

## Additional Improvements
- Update product name to "YMulator-Synth" in release notes template
- Maintain exact same formatting and content in the final output
- More robust and maintainable approach for future changes

## Test Results
This approach is more compatible with GitHub Actions bash environment and should resolve the workflow failures.

🤖 Generated with [Claude Code](https://claude.ai/code)